### PR TITLE
Update _clientids.gsc

### DIFF
--- a/Zombies Mods/Zombies++ v1.2/Source Code/_clientids.gsc
+++ b/Zombies Mods/Zombies++ v1.2/Source Code/_clientids.gsc
@@ -10,6 +10,7 @@
 #include maps/mp/zombies/_zm_perks;
 #include maps/mp/zombies/_zm_audio;
 #include maps/mp/zombies/_zm_score;
+#include maps/mp/zombies/_zm_equipment;
 
 init()
 {


### PR DESCRIPTION
missed an include needed for equipment_take() when copying them over. my bad.
compiles and runs on motd, die rise, and origins with no issue. haven't tested other maps. 